### PR TITLE
fix a TextField demo typo

### DIFF
--- a/Android/LuaViewDemo/assets/test/UI_TextField.lua
+++ b/Android/LuaViewDemo/assets/test/UI_TextField.lua
@@ -19,7 +19,7 @@ tf.callback({
 
 local btn1 = Button()
 btn1.callback(function()
-    tf.setText("点击了")
+    tf.text("点击了")
 end)
 
 


### PR DESCRIPTION
Hi, According to the code: https://github.com/alibaba/LuaViewSDK/blob/58c4a56b24e31643bcec4f569a0aaa8890ca0a9d/IOS/LuaViewSDK/Classes/lvsdk/LVTextField.m#L190

It seems we need to change setText to text if we were going to run the textfield demo on iOS.
