### PR TITLE
真机调试和printLog

### DIFF
--- a/Android/LuaViewSDK/src/com/taobao/luaview/debug/DebugConnection.java
+++ b/Android/LuaViewSDK/src/com/taobao/luaview/debug/DebugConnection.java
@@ -14,13 +14,17 @@ public class DebugConnection extends Socket {
 
     private static final String EMULATOR_LOCALHOST = "10.0.2.2";
     private static final String GENYMOTION_LOCALHOST = "10.0.3.2";
-    private static final String DEVICE_LOCALHOST = "localhost";
+    private static String DEVICE_LOCALHOST = "localhost";
     private static final int PORT = 9876;
 
     private DataInputStream input = null;
     private DataOutputStream output = null;
 
     public boolean sendingEnabled = true;
+	
+	public static void setDeviceLocalhost(String deviceLocalhost) {
+		DEVICE_LOCALHOST = deviceLocalhost;
+	}
 
     private static String getDebugServerHost() {
         // Since genymotion runs in vbox it use different hostname to refer to adb host.

--- a/Android/LuaViewSDK/src/com/taobao/luaview/vm/extend/BaseLib.java
+++ b/Android/LuaViewSDK/src/com/taobao/luaview/vm/extend/BaseLib.java
@@ -26,7 +26,7 @@ public class BaseLib {
 
     public void extend(LuaValue env) {
         env.set("printLV", new printLV(baseLib));
-		env.set("log", new log(baseLib));
+		env.set("printLog", new printLog(baseLib));
     }
 
     // "print", // (...) -> void
@@ -58,8 +58,8 @@ public class BaseLib {
         }
     }
 	
-	// "log(fileName, messsage)", send log info to LuaViewDebugger
-	final class log extends TwoArgFunction {
+	// "printLog(fileName, messsage)", send log info to LuaViewDebugger
+	final class printLog extends TwoArgFunction {
 		final org.luaj.vm2.lib.BaseLib baseLib;
 
 		public log(org.luaj.vm2.lib.BaseLib baseLib) {

--- a/Android/LuaViewSDK/src/com/taobao/luaview/vm/extend/BaseLib.java
+++ b/Android/LuaViewSDK/src/com/taobao/luaview/vm/extend/BaseLib.java
@@ -26,6 +26,7 @@ public class BaseLib {
 
     public void extend(LuaValue env) {
         env.set("printLV", new printLV(baseLib));
+		env.set("log", new log(baseLib));
     }
 
     // "print", // (...) -> void
@@ -56,4 +57,22 @@ public class BaseLib {
             return NONE;
         }
     }
+	
+	// "log(fileName, messsage)", send log info to LuaViewDebugger
+	final class log extends TwoArgFunction {
+		final org.luaj.vm2.lib.BaseLib baseLib;
+
+		public log(org.luaj.vm2.lib.BaseLib baseLib) {
+			this.baseLib = baseLib;
+		}
+
+		@Override public LuaValue call(LuaValue arg1, LuaValue arg2) {
+			String fileName = arg1.checkjstring();
+			if (globals.debugConnection != null) {
+				globals.debugConnection.sendCmd("log", fileName, arg2.checkjstring());
+			}
+			LogUtil.i(arg2);
+			return NONE;
+		}
+	}
 }


### PR DESCRIPTION
1、修改了DebugConnection.java，可以设置DEVICE_LOACALHOST，这样可以进行真机调试。
2、添加了一个printLog基本方法，可以发送log信息到LuaViewDebugger。

要进行真机调试Android项目可以在Application或者是Activity的onCreate()中进行设置如下代码：
LuaViewConfig.setDebug(true);
LuaViewConfig.setOpenDebugger(true);
DebugConnection.setDeviceLocalhost("your pc ip");

在Activity中设置要在LuaView创建之前设置。